### PR TITLE
Adds docker and selinux validation

### DIFF
--- a/pytest_molecule.py
+++ b/pytest_molecule.py
@@ -1,8 +1,34 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
+import logging
 import os
 import pytest
 import subprocess
+import sys
+
+
+def pytest_configure(config):
+
+    import docker
+
+    # validate docker conectivity
+    c = docker.from_env(timeout=5, version="auto")
+    if not c.ping():
+        raise Exception("Failed to ping docker server.")
+
+    # validate selinux availability
+    if sys.platform == 'linux':
+        try:
+            import selinux  # noqa
+        except Exception as e:
+            logging.error(
+                "It appears that you are trying to use "
+                "molecule with a Python interpreter that does not have the "
+                "libselinux python bindings installed. These can only be "
+                "installed using your distro package manager and are specific "
+                "to each python version. Common package names: "
+                "libselinux-python python2-libselinux python3-libselinux")
+            raise e
 
 
 def pytest_collect_file(parent, path):

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,11 @@ envlist = lint,py27,py35,py36,py37
 
 [testenv]
 deps =
-    docker
-    paramiko
+    docker>=4.0.1
+    paramiko>=2.5.0
     pytest>=3.0
-    pytest-html
+    pytest-html>=1.21.0
+    selinux>=0.1.5rc1
 commands =
     pytest --color=yes --html={envlogdir}/reports.html --self-contained-html {tty:-s} {posargs:tests}
 setenv =


### PR DESCRIPTION
Current both docker and selinux are needed in order to be able to run molecule.

This validation code will assure that pytest will not even run when environment is not ready for running the tests.