### PR TITLE
Increase docker API timeout

### DIFF
--- a/pytest_molecule/__init__.py
+++ b/pytest_molecule/__init__.py
@@ -11,8 +11,10 @@ def pytest_configure(config):
 
     import docker
 
-    # validate docker conectivity
-    c = docker.from_env(timeout=5, version="auto")
+    # validate docker connectivity
+    # Default docker value is 60s but we want to fail faster
+    # With parallel execution 5s proved to give errors.
+    c = docker.from_env(timeout=10, version="auto")
     if not c.ping():
         raise Exception("Failed to ping docker server.")
 


### PR DESCRIPTION
While we started testing parallel usage we discovered that the 5 seconds timeout was too small.

Increating this to 10s to assure it does not fail. In the future we may want to make it configurable or to default to 60 seconds which is the current default on python docker api client.

Related-To: https://github.com/ssbarnea/molex/issues/1