### PR TITLE
Enables passing options via MOLECULE_OPTS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,9 @@ and runs them as pytest tests.
 Once you install pytest-molecule you should be able to just run `pytest` in order
 to run molecule on all roles and scenarios.
 
+Optionally you can define `MOLECULE_OPTS` for passing extra parameters to each
+molecule call.
+
 Installation
 ------------
 

--- a/pytest_molecule/__init__.py
+++ b/pytest_molecule/__init__.py
@@ -4,7 +4,9 @@ import logging
 import os
 import pytest
 import subprocess
+import shlex
 import sys
+from pipes import quote
 
 
 def pytest_configure(config):
@@ -58,7 +60,14 @@ class MoleculeItem(pytest.Item):
         scenario = folders[-1]
         role = folders[-3]  # noqa
         cmd = [sys.executable, "-m", "molecule", self.name, "-s", scenario]
-        print("running: %s (from %s)" % (" ".join(cmd), cwd))
+
+        # We append the additional options to molecule call, allowing user to
+        # control how molecule is called by pytest-molecule
+        opts = os.environ.get("MOLECULE_OPTS")
+        if opts:
+            cmd.extend(shlex.split(opts))
+
+        print("running: %s (from %s)" % (" ".join(quote(arg) for arg in cmd), cwd))
 
         try:
             # Workaround for STDOUT/STDERR line ordering issue:

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,9 @@ setenv =
     # pip: Avoid 2020-01-01 warnings: https://github.com/pypa/pip/issues/6207
     PYTHONWARNINGS=ignore:DEPRECATION::pip._internal.cli.base_command
     PYTHONDONTWRITEBYTECODE=1
+    # This should pass these args to molecule, no effect here as this is the default
+    # but it validates that it accepts extra params.
+    MOLECULE_OPTS=--destroy always
 passenv =
     TWINE_*
 whitelist_externals =


### PR DESCRIPTION
If user defines MOLECULE_OPTS environment variable, this will be added
to molecule calls made by pytest.

Example use:
MOLECULE_OPTS=--destroy never