### PR TITLE
Docker should be optional

### DIFF
--- a/pytest_molecule/__init__.py
+++ b/pytest_molecule/__init__.py
@@ -33,15 +33,6 @@ def pytest_configure(config):
         )
     config.addinivalue_line("markers", "molecule: mark used by all molecule scenarios")
 
-    import docker
-
-    # validate docker connectivity
-    # Default docker value is 60s but we want to fail faster
-    # With parallel execution 5s proved to give errors.
-    c = docker.from_env(timeout=10, version="auto")
-    if not c.ping():
-        raise Exception("Failed to ping docker server.")
-
     # validate selinux availability
     if sys.platform == "linux" and os.path.isfile("/etc/selinux/config"):
         try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,8 +71,8 @@ install_requires =
 
 [options.extras_require]
 docker =
-    docker
-    paramiko
+    docker>=4.0.1
+    paramiko>=2.5.0
 
 [options.entry_points]
 pytest11 =

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,6 @@ install_command =
     python -c 'import subprocess, sys; pip_inst_cmd = sys.executable, "-m", "pip", "install"; subprocess.check_call(pip_inst_cmd + ("pip<19.1", )); subprocess.check_call(pip_inst_cmd + tuple(sys.argv[1:]))' {opts} {packages}
 usedevelop = True
 deps =
-    docker>=4.0.1
-    paramiko>=2.5.0
     pep517>=0.5.0
     pytest>=3.0
     pytest-html>=1.21.0
@@ -55,6 +53,9 @@ whitelist_externals =
 description =
     Validate that we can install the wheel w/ or w/o extras on Ubuntu, Debian,
     Fedora, RHEL 8 and CentOS 7 by using containers.
+# our distros molecule tests are using docker
+extras =
+    docker
 commands =
     python -m pep517.build \
       --source \


### PR DESCRIPTION
pytest-molecule should not install or require docker unless this
is installed by the user.

This is needed because not all molecule users are using docker
driver and they should have the full freedom to pick their own
drivers.