### PR TITLE
Speedup testing by using pys pre-build images

### DIFF
--- a/tests/roles/ensure-ansible/molecule/default/molecule.yml
+++ b/tests/roles/ensure-ansible/molecule/default/molecule.yml
@@ -7,13 +7,13 @@ platforms:
 
   - name: centos7
     hostname: centos7
-    image: centos:7
+    image: pycontribs/centos:7
     dockerfile: ../Dockerfile.j2
     network_mode: host
 
   - name: fedora
     hostname: fedora
-    image: fedora:latest
+    image: pycontribs/fedora:latest
     dockerfile: ../Dockerfile.j2
     network_mode: host
 
@@ -27,13 +27,13 @@ platforms:
 
   - name: ubuntu
     hostname: ubuntu
-    image: ubuntu:latest
+    image: pycontribs/ubuntu:latest
     dockerfile: ../Dockerfile.j2
     network_mode: host
 
   - name: debian
     hostname: debian
-    image: debian:latest
+    image: pycontribs/debian:latest
     dockerfile: ../Dockerfile.j2
     network_mode: host
 

--- a/tests/roles/ensure-ansible/vars/debian-10.yml
+++ b/tests/roles/ensure-ansible/vars/debian-10.yml
@@ -1,2 +1,5 @@
+pre_packages:
+  - sudo
+
 packages:
   - python3-pip

--- a/tests/roles/ensure-ansible/vars/ubuntu.yml
+++ b/tests/roles/ensure-ansible/vars/ubuntu.yml
@@ -1,5 +1,8 @@
 pre_packages:
+  - aptitude
   - python3
+  - python3-apt
+  - sudo
 
 packages:
   - python3-pip


### PR DESCRIPTION
Instead of testing packaging compatibility across distros we start using
pre-build images produced by https://github.com/pycontribs/pys

This should lower the time needed to run `tox -e distros` to less than
a half.