### PR TITLE
Fix pytest serialization issue

### DIFF
--- a/pytest_molecule/__init__.py
+++ b/pytest_molecule/__init__.py
@@ -47,7 +47,7 @@ def pytest_configure(config):
         warnings.filterwarnings("ignore", category=DeprecationWarning)
 
         config.option.molecule = {}
-        for driver in drivers():
+        for driver in map(str, drivers()):
             config.addinivalue_line(
                 "markers",
                 "{0}: mark test to run only when {0} is available".format(driver),


### PR DESCRIPTION
Mainly pytest options must be serializable and our code was passing
Driver instances instead of strings to pytest options dictionary.

This was breaking python-xdist module, even if pytest-molecule was
not used.

Related: https://github.com/pytest-dev/pytest-xdist/issues/464