### PR TITLE
Avoid adding skip marker by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,9 +50,8 @@ All tests are added the ``molecule`` marker.
 
 This plugin also adds a new pytest option named
 ``--molecule-unavailable-driver=skip`` which can be used to tell it what to do
-when molecule drivers are not loading. Current default is ``skip`` but you
-can choose other marks like ``xfail`` or empty string if you want to disable
-this functionality.
+when molecule drivers are not loading. Current default is ``None`` but you
+can choose marks like ``skip`` or ``xfail``.
 
 Installation
 ------------

--- a/pytest_molecule/__init__.py
+++ b/pytest_molecule/__init__.py
@@ -21,9 +21,9 @@ def pytest_addoption(parser):
     group = parser.getgroup("molecule")
     help_msg = (
         "What marker to add to molecule scenarios when driver is "
-        "unavailable. (ex: skip, xfail)"
+        "unavailable. (ex: skip, xfail). Default: None"
     )
-    default = "skip"
+    default = None
     dest = "molecule_unavailable_driver"
 
     group.addoption(


### PR DESCRIPTION
From now on, we will not add implicit skip marker if a driver is
missing. This default behavior proved to be a source of false-positive
results.

Fixes: #56