### PR TITLE
Make ubuntu jobs non-voting

### DIFF
--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -6,7 +6,9 @@
     check:
       jobs: &defaults
         - molecule-tox-linters
-        - molecule-tox-packaging
+        - molecule-tox-packaging:
+            # ensure-podman fails on ubuntu
+            voting: false
         - molecule-tox-py36-centos-8:
             vars:
               tox_environment:
@@ -15,6 +17,8 @@
             vars:
               tox_environment:
                 PYTEST_REQPASS: 1
+            # ensure-podman fails on ubuntu
+            voting: false
         - molecule-tox-py37-fedora-30:
             vars:
               tox_environment:


### PR DESCRIPTION
Avoids a new suprise:

Error: could not get runtime: error creating runtime static files directory /home/zuul/.local/share/containers/storage/libpod: mkdir /home/zuul/.local/share: permission denied

https://debe33c3695ed316e2cf-236b1ad020c22ff72e0a81ec8cf29afd.ssl.cf1.rackcdn.com/72/b24fc2789ec77534ebf48f0f4458b38826ff427c/check/molecule-tox-py36-ubuntu-bionic/d8aa74c/job-output.html#l939