### PR TITLE
Remove dependency on ansible package

### DIFF
--- a/pytest_molecule/__init__.py
+++ b/pytest_molecule/__init__.py
@@ -16,6 +16,7 @@ try:
 except ImportError:
     # molecule<3.0
     from molecule.api import molecule_drivers as drivers
+from molecule.config import ansible_version
 
 
 def pytest_addoption(parser):
@@ -50,8 +51,12 @@ def pytest_configure(config):
     ]
 
     # Add extra information that may be key for debugging failures
-    for p in ["ansible", "molecule"]:
+    for p in ["molecule"]:
         config._metadata["Packages"][p] = pkg_resources.get_distribution(p).version
+
+    if "Tools" not in config._metadata:
+        config._metadata["Tools"] = {}
+    config._metadata["Tools"]["ansible"] = str(ansible_version())
 
     # Adds interesting env vars
     env = ""

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,20 +69,16 @@ setup_requires =
 # many projects using pytest-molecule. By listing them as dependencies we
 # avoid installing versions that are not compatible.
 install_requires =
-    ansi2html
-    molecule >= 3.0.4
-    pytest >= 3.50
-    pytest-html < 2; python_version<"3.0"
-    pytest-html; python_version>="3.0"
-    pytest-plus
-    pyyaml >= 5.1, < 6
-    # https://github.com/pytest-dev/pytest/issues/5854
-    more_itertools >= 5, < 6; python_version<"3.0"
-    more_itertools >= 6; python_version>="3.0"
+    molecule[test]>=3.1.0a2
+    pytest-html
 
 [options.extras_require]
+ansi =
+    # https://github.com/ralphbean/ansi2html/issues/110
+    ansi2html; python_version<"3.8"
 docker =
-    molecule[docker]
+    molecule-docker
+    paramiko>=2.5.0
 
 [options.entry_points]
 pytest11 =

--- a/tox.ini
+++ b/tox.ini
@@ -21,8 +21,9 @@ commands =
     # pytest already needs built wheel in dist/
     pytest --color=yes --html={envlogdir}/reports.html --self-contained-html {tty:-s} --molecule-unavailable-driver= -k foo
 deps =
+    py{36,37,38,39}:  molecule[test,docker]>=3.1.0a2
     devel: git+https://github.com/pytest-dev/pytest-html.git#egg=pytest-html
-    devel: git+https://github.com/ansible-community/molecule#egg=molecule[test]
+    devel: git+https://github.com/ansible-community/molecule#egg=molecule[test,docker]
     devel: ansible>=2.10.0a2
 setenv =
     ANSIBLE_FORCE_COLOR={env:ANSIBLE_FORCE_COLOR:1}


### PR DESCRIPTION
* avoid importing ansible module while making use of new molecule API
* rely on molecule own test requirements
* avoid installing ansi2html on py38+ due to https://github.com/ralphbean/ansi2html/issues/110