### PR TITLE
Use pre-commit hook defined in .github repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,46 +1,5 @@
----
 repos:
-  - repo: https://github.com/PyCQA/doc8.git
-    rev: 0.9.0a1
+  - repo: https://github.com/ansible-community/.github
+    rev: 2b9c14a9166736645b616c29f6b834e8c915bb30
     hooks:
-      - id: doc8
-  - repo: https://github.com/python/black
-    rev: 20.8b1
-    hooks:
-      - id: black
-        language_version: python3
-  - repo: https://github.com/pre-commit/pre-commit-hooks.git
-    rev: v3.2.0
-    hooks:
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
-      - id: mixed-line-ending
-      - id: check-byte-order-marker
-      - id: check-executables-have-shebangs
-      - id: check-merge-conflict
-      - id: debug-statements
-  - repo: https://gitlab.com/pycqa/flake8.git
-    rev: 3.8.4
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-black
-  - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.25.0
-    hooks:
-      - id: yamllint
-        files: \.(yaml|yml)$
-        types: [file, yaml]
-        entry: yamllint --strict
-  - repo: https://github.com/codespell-project/codespell.git
-    rev: v1.17.1
-    hooks:
-      - id: codespell
-        name: codespell
-        description: Checks for common misspellings in text files.
-        entry: codespell
-        language: python
-        types: [text]
-        args: []
-        require_serial: false
-        additional_dependencies: []
+      - id: shared-hooks


### PR DESCRIPTION
## WIP: something does is not right...

# pre-commit run -a (twice)
Apparently this change runs the hooks bug twice, as seen at:
![](https://sbarnea.com/ss/Screen-Shot-2020-10-14-16-17-13.48.png)

Before doing this change, they did run only once....

# tox -e linters (lots of times)
This is supposed to have identical behavior as running `pre-commit run -a` from outside tox, as tox is used only to install pre-comit, still the result is very different than running pre-commit directly:

```
$ tox -e linters                                                                                                  [16:15:20]
linters installed: appdirs==1.4.4,cfgv==3.2.0,distlib==0.3.1,filelock==3.0.12,identify==1.5.6,nodeenv==1.5.0,pre-commit==2.7.1,pytest-molecule==1.3.1.dev4+g1b40a51.d20201014,PyYAML==5.3.1,six==1.15.0,toml==0.10.1,virtualenv==20.0.34
linters run-test-pre: PYTHONHASHSEED='3679077318'
linters run-test: commands[0] | pre-commit run -a
shared-hooks.............................................................Passed
- hook id: shared-hooks
- duration: 5.32s

isort................................................(no files to check)Skipped
black................................................(no files to check)Skipped
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
Mixed line ending........................................................Passed
Check for byte-order marker..............................................Passed
Check that executables have shebangs.................(no files to check)Skipped
Check for merge conflicts................................................Passed
Debug Statements (Python)............................(no files to check)Skipped
flake8...............................................(no files to check)Skipped
yamllint.................................................................Passed
mypy.................................................(no files to check)Skipped
pylint...............................................(no files to check)Skipped
isort....................................................................Passed
black....................................................................Passed
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
Mixed line ending........................................................Passed
Check for byte-order marker..............................................Passed
Check that executables have shebangs.................(no files to check)Skipped
Check for merge conflicts................................................Passed
Debug Statements (Python)................................................Passed
flake8...................................................................Passed
yamllint.................................................................Passed
...
```

