### PR TITLE
Added more convenience extras

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -74,11 +74,14 @@ install_requires =
 
 [options.extras_require]
 ansi =
-    # https://github.com/ralphbean/ansi2html/issues/110
-    ansi2html; python_version<"3.8"
+    ansi2html
 docker =
     molecule-docker
     paramiko>=2.5.0
+podman =
+    molecule-podman
+vagrant =
+    molecule-vagrant
 
 [options.entry_points]
 pytest11 =

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,12 @@ commands =
     pytest --collect-only
     # pytest already needs built wheel in dist/
     pytest --color=yes --html={envlogdir}/reports.html --self-contained-html {tty:-s} --molecule-unavailable-driver= -k foo
+# all extras installed in order to detect potential conflicts
+extras =
+    ansi
+    docker
+    podman
+    vagrant
 deps =
     py{36,37,38,39}:  molecule[test,docker]>=3.1.0a2
     devel: git+https://github.com/pycontribs/ansi2html.git#egg=ansi2html
@@ -36,6 +42,7 @@ setenv =
     ANSIBLE_STDOUT_CALLBACK={env:ANSIBLE_STDOUT_CALLBACK:debug}
     ANSIBLE_VERBOSITY={env:ANSIBLE_VERBOSITY:0}
     PIP_DISABLE_PIP_VERSION_CHECK=1
+    PIP_USE_FEATURE=2020-resolver
     PY_COLORS={env:PY_COLORS:1}
     # pip: Avoid 2020-01-01 warnings: https://github.com/pypa/pip/issues/6207
     PYTHONWARNINGS=ignore:DEPRECATION::pip._internal.cli.base_command


### PR DESCRIPTION
This should enable users to only mention pytest-molecule and the desired extras in order to get a full set of requirements, avoiding potential conflicts and making upgrades much easier.