### PR TITLE
Make driver and platforms config sections optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,9 @@ markers_, so you can selectively limit which test types to run:
     # Runs scenarios with platform named centos7 and delegated driver:
     $ pytest -m delegated -m centos7
 
+If the molecule scenario does not contain information about the driver, the
+test associated with it gets a ``no_driver`` mark.
+
 Please note that at this moment molecule will run the entire scenario if the
 markers are platforms, this is not *yet* a way to limit which platforms are
 executed inside a specific scenario.

--- a/tests/roles/no_drivers/molecule/default/molecule.yml
+++ b/tests/roles/no_drivers/molecule/default/molecule.yml
@@ -1,0 +1,3 @@
+---
+platforms:
+  - name: localhost

--- a/tests/roles/no_platforms/molecule/default/molecule.yml
+++ b/tests/roles/no_platforms/molecule/default/molecule.yml
@@ -1,0 +1,3 @@
+---
+driver:
+  name: delegated


### PR DESCRIPTION
Current implementation mandates that at least driver and platforms sections are present in all molecule.yml scenario configuration files. But because those two pieces of information can also come from the base configuration file, it does not feel right to fail when they are not present in the scenario configuration.

This commit makes those two sections optional. Missing platfroms section is simply interpreted as an empty list since this does not change the final outcome at all.

The missing driver section is treated a bit differently because the driver name is used in a few different places. In order not to break backward-compatibility, we use the "no_driver" string as driver name if the driver section is not present or if the driver name is not set in the scenario config.