### PR TITLE
Support test setups that use base config file

### DIFF
--- a/pytest_molecule/__init__.py
+++ b/pytest_molecule/__init__.py
@@ -22,25 +22,24 @@ if TYPE_CHECKING:
     from _pytest.nodes import Node
 
 
+def _addoption(group, parser, ini_dest, default, help_msg):
+    opt = "--" + ini_dest.replace("_", "-")
+    group.addoption(opt, action="store", dest=ini_dest, default=default, help=help_msg)
+    parser.addini(ini_dest, help_msg, default=default)
+
+
 def pytest_addoption(parser):
     """Inject new command line options to pytest."""
     group = parser.getgroup("molecule")
-    help_msg = (
+
+    _addoption(
+        group,
+        parser,
+        "molecule_unavailable_driver",
+        None,
         "What marker to add to molecule scenarios when driver is "
-        "unavailable. (ex: skip, xfail). Default: None"
+        "unavailable. (ex: skip, xfail). Default: None",
     )
-    default = None
-    dest = "molecule_unavailable_driver"
-
-    group.addoption(
-        "--molecule-unavailable-driver",
-        action="store",
-        dest=dest,
-        default=default,
-        help=help_msg,
-    )
-
-    parser.addini(dest, help_msg, default=default)
 
 
 def pytest_configure(config):

--- a/pytest_molecule/__init__.py
+++ b/pytest_molecule/__init__.py
@@ -40,6 +40,14 @@ def pytest_addoption(parser):
         "What marker to add to molecule scenarios when driver is "
         "unavailable. (ex: skip, xfail). Default: None",
     )
+    _addoption(
+        group,
+        parser,
+        "molecule_base_config",
+        None,
+        "Path to the molecule base config file. The value of this option is "
+        "passed to molecule via the --base-config flag. Default: None",
+    )
 
 
 def pytest_configure(config):
@@ -168,8 +176,11 @@ class MoleculeItem(pytest.Item):
         cwd = os.path.abspath(os.path.join(self.fspath.dirname, "../.."))
         scenario = folders[-1]
         # role = folders[-3]  # noqa
-        cmd = [sys.executable, "-m", "molecule", self.name, "-s", scenario]
 
+        cmd = [sys.executable, "-m", "molecule"]
+        if self.config.option.molecule_base_config:
+            cmd.extend(("--base-config", self.config.option.molecule_base_config))
+        cmd.extend((self.name, "-s", scenario))
         # We append the additional options to molecule call, allowing user to
         # control how molecule is called by pytest-molecule
         opts = os.environ.get("MOLECULE_OPTS")

--- a/tests/roles/base_config/base.yml
+++ b/tests/roles/base_config/base.yml
@@ -1,0 +1,4 @@
+---
+scenario:
+  test_sequence:
+    - converge

--- a/tests/roles/base_config/molecule/s1/converge.yml
+++ b/tests/roles/base_config/molecule/s1/converge.yml
@@ -1,0 +1,7 @@
+- name: Converge
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Converge on s1
+      debug:
+        msg: Scenario 1

--- a/tests/roles/base_config/molecule/s1/molecule.yml
+++ b/tests/roles/base_config/molecule/s1/molecule.yml
@@ -1,0 +1,6 @@
+---
+driver:
+  name: delegated
+
+platforms:
+  - name: localhost

--- a/tests/roles/base_config/molecule/s1/prepare.yml
+++ b/tests/roles/base_config/molecule/s1/prepare.yml
@@ -1,0 +1,8 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: This should not be executed if base config file is loaded
+      fail:
+        msg: Base config file loading is not working as expected

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,11 @@ commands =
     pytest --collect-only
     # pytest already needs built wheel in dist/
     pytest --color=yes --html={envlogdir}/reports.html --self-contained-html {tty:-s} --molecule-unavailable-driver= -k foo
+    pytest \
+      --molecule-base-config base.yml \
+      --color=yes \
+      {tty:-s} \
+      -k base_config
 # all extras installed in order to detect potential conflicts
 extras =
     ansi


### PR DESCRIPTION
Up until now, it was fairly inconvenient to run molecule test suites that used based configuration file to reduce the duplication of content in the scenario configs.

This commit adds a command line flag and related INI config option that allows us to pass --base-config flag to molecule when running tests.