### PR TITLE
Update tox minimum version and add fix for deprecated option

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-minversion = 3.9.0
+minversion = 3.18.0
 envlist =
     linters
     devel
@@ -65,7 +65,7 @@ passenv =
     SSL_CERT_FILE
     TOXENV
     TWINE_*
-whitelist_externals =
+allowlist_externals =
     ansible-inventory
     bash
     twine


### PR DESCRIPTION
Was getting a deprecated option warning, this text is changed to `allowlist_externals` in newer versions:
https://tox.readthedocs.io/en/latest/changelog.html#v3-18-0-2020-07-23