### PR TITLE
Avoid recognizing symlinked folders as scenarios

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: black
         language_version: python3
   - repo: https://github.com/pre-commit/pre-commit-hooks.git
-    rev: v3.2.0
+    rev: v3.4.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -33,7 +33,7 @@ repos:
         types: [file, yaml]
         entry: yamllint --strict
   - repo: https://github.com/codespell-project/codespell.git
-    rev: v1.17.1
+    rev: v2.0.0
     hooks:
       - id: codespell
         name: codespell

--- a/pytest_molecule/__init__.py
+++ b/pytest_molecule/__init__.py
@@ -21,6 +21,8 @@ from molecule.config import ansible_version
 if TYPE_CHECKING:
     from _pytest.nodes import Node
 
+LOGGER = logging.getLogger(__name__)
+
 
 def _addoption(group, parser, ini_dest, default, help_msg):
     opt = "--" + ini_dest.replace("_", "-")
@@ -123,6 +125,11 @@ def pytest_configure(config):
 
 def pytest_collect_file(parent, path) -> Optional["Node"]:
     """Transform each found molecule.yml into a pytest test."""
+
+    # We do not want to recognize paths with symlinks as valid
+    if os.path.realpath(path) != path:
+        return None
+
     if path.basename == "molecule.yml":
         if hasattr(MoleculeFile, "from_parent"):
             return MoleculeFile.from_parent(fspath=path, parent=parent)


### PR DESCRIPTION
Avoids duplication of scenarios when people create role aliases.