### PR TITLE
Avoid pre-release dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Software Development :: Testing
@@ -69,7 +70,7 @@ setup_requires =
 # many projects using pytest-molecule. By listing them as dependencies we
 # avoid installing versions that are not compatible.
 install_requires =
-    molecule[test]>=3.1.0a2
+    molecule[test]>=3.1.0
     pytest-html
 
 [options.extras_require]

--- a/tox.ini
+++ b/tox.ini
@@ -32,11 +32,11 @@ extras =
     podman
     vagrant
 deps =
-    py{36,37,38,39}:  molecule[test,docker]>=3.1.0a2
+    py{36,37,38,39}:  molecule[test,docker]
     devel: git+https://github.com/pycontribs/ansi2html.git#egg=ansi2html
     devel: git+https://github.com/pytest-dev/pytest-html.git#egg=pytest-html
     devel: git+https://github.com/ansible-community/molecule#egg=molecule[test,docker]
-    devel: ansible>=2.10.0a2
+    devel: ansible>=2.10
 setenv =
     ANSIBLE_FORCE_COLOR={env:ANSIBLE_FORCE_COLOR:1}
     # ANSIBLE_INVENTORY={env:ANSIBLE_INVENTORY:{toxinidir}/../zuul-infra/inventory.yml}


### PR DESCRIPTION
Use of pre-release dependencies has serious implications at it will pick any pre-release, mainly activating `--pre` on pip.