### PR TITLE
Add ability to use xfail and skip markers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,17 @@ This plugin also adds a new pytest option named
 when molecule drivers are not loading. Current default is ``None`` but you
 can choose marks like ``skip`` or ``xfail``.
 
+Using xfail and skip markers
+----------------------------
+
+If you need to skip or ignore a particular scenario, just add either ``xfail``
+or ``skip`` to markers list inside its config file.
+
+.. code-block:: yaml
+
+    markers:
+      - xfail  # broken scenario, pytest will run it but ignore the result
+
 Installation
 ------------
 

--- a/src/pytest_molecule/__init__.py
+++ b/src/pytest_molecule/__init__.py
@@ -173,6 +173,19 @@ class MoleculeItem(pytest.Item):
             self.molecule_driver = data.get("driver", {}).get("name", "no_driver")
             self.add_marker(self.molecule_driver)
 
+            # check for known markers and add them
+            markers = data.get("markers", [])
+            if "xfail" in markers:
+                self.add_marker(
+                    pytest.mark.xfail(
+                        reason="Marked as broken by scenario configuration."
+                    )
+                )
+            if "skip" in markers:
+                self.add_marker(
+                    pytest.mark.skip(reason="Disabled by scenario configuration.")
+                )
+
             # we also add platforms as marks
             for platform in data.get("platforms", []):
                 platform_name = platform["name"]

--- a/tests/roles/foo/molecule/disabled/converge.yml
+++ b/tests/roles/foo/molecule/disabled/converge.yml
@@ -1,0 +1,8 @@
+- name: Converge
+  hosts: all
+  gather_facts: false
+  tasks:
+
+    - name: Impossible task
+      fail:
+        msg: "That playbook should never pass!"

--- a/tests/roles/foo/molecule/disabled/molecule.yml
+++ b/tests/roles/foo/molecule/disabled/molecule.yml
@@ -1,0 +1,17 @@
+---
+driver:
+  name: delegated
+
+platforms:
+  - name: localhost
+
+provisioner:
+  name: ansible
+  log: true
+
+scenario:
+  test_sequence:
+    - converge
+
+markers:
+  - xfail


### PR DESCRIPTION
Allow users to use `xfail` or `skip` markers inside molecule scenario files to modify their execution.