### PR TITLE
Remove test extra from molecule dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ setup_requires =
 # many projects using pytest-molecule. By listing them as dependencies we
 # avoid installing versions that are not compatible.
 install_requires =
-    molecule[test]>=3.1.0
+    molecule>=3.1.0
     pytest-html
 
 [options.extras_require]


### PR DESCRIPTION
Extra testing requirements are only needed if we want to test molecule itself. And since pytest-molecule does not test molecule itself, test requirements are not needed.