### PR TITLE
Require pytest>=7.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,7 @@ install_requires =
     molecule>=3.1.0
     molecule>=3.5.2; python_version>='3.10'
     pytest-html
+    pytest>=7.0.0
 
 [options.extras_require]
 ansi =


### PR DESCRIPTION
Main reason for this change is the deprecation of py in newer pytest versions.

Closes: #114