### PR TITLE
Add --skip-no-git-change option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,14 @@ This plugin also adds a new pytest option named
 when molecule drivers are not loading. Current default is ``None`` but you
 can choose marks like ``skip`` or ``xfail``.
 
+The plugin adds ``--skip-no-git-change`` option which an be used to skip tests
+on unchanged roles according to ``git diff`` result and thus can only be used
+only when running pytest inside a git repository. It takes one argument and old
+refspec used as a reference. For instance calling:
+``pytest --skip-no-git-change HEAD^`` will result in molecule of roles that
+weren't changed in the last commit being skipped.
+
+
 Using xfail and skip markers
 ----------------------------
 

--- a/src/pytest_molecule/__init__.py
+++ b/src/pytest_molecule/__init__.py
@@ -61,6 +61,7 @@ def pytest_addoption(parser):
         "changed since this commit skip the test. Default: None",
     )
 
+
 def pytest_configure(config):
     """Pytest hook for loading our specific configuration."""
     interesting_env_vars = [
@@ -231,8 +232,8 @@ class MoleculeItem(pytest.Item):
                     proc.wait()
                     if len(proc.stdout.readlines()) == 0:
                         pytest.skip("No change in role")
-            except Exception as exc: # pylint: disable=broad-except
-                pytest.fail("Error checking git diff. Error was:"+str(exc))
+            except Exception as exc:  # pylint: disable=broad-except
+                pytest.fail("Error checking git diff. Error was:" + str(exc))
 
         cmd.extend((self.name, "-s", scenario))
         # We append the additional options to molecule call, allowing user to

--- a/src/pytest_molecule/__init__.py
+++ b/src/pytest_molecule/__init__.py
@@ -52,7 +52,14 @@ def pytest_addoption(parser):
         "Path to the molecule base config file. The value of this option is "
         "passed to molecule via the --base-config flag. Default: None",
     )
-
+    _addoption(
+        group,
+        parser,
+        "skip_no_git_change",
+        None,
+        "Commit to use as a reference for this test. If the role wasn't"
+        "changed since this commit skip the test. Default: None",
+    )
 
 def pytest_configure(config):
     """Pytest hook for loading our specific configuration."""
@@ -212,6 +219,21 @@ class MoleculeItem(pytest.Item):
         cmd = [sys.executable, "-m", "molecule"]
         if self.config.option.molecule_base_config:
             cmd.extend(("--base-config", self.config.option.molecule_base_config))
+        if self.config.option.skip_no_git_change:
+            try:
+                with subprocess.Popen(
+                    ["git", "diff", self.config.option.skip_no_git_change, "--", "./"],
+                    cwd=cwd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    universal_newlines=True,
+                ) as proc:
+                    proc.wait()
+                    if len(proc.stdout.readlines()) == 0:
+                        pytest.skip("No change in role")
+            except Exception as exc: # pylint: disable=broad-except
+                pytest.fail("Error checking git diff. Error was:"+str(exc))
+
         cmd.extend((self.name, "-s", scenario))
         # We append the additional options to molecule call, allowing user to
         # control how molecule is called by pytest-molecule


### PR DESCRIPTION
Add ``--skip-no-git-change`` option which can be used to skip tests on unchanged roles according to ``git diff`` result. In big environments running all molecule tests on every pull request/merge request may require too much resources while the results of each molecules may be very likely separated. #enhancement

Closes: #115